### PR TITLE
README.md: Fix markup of CLI build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 This is the ClanLib 4.1 version of the Super Methane Brothers game.
 
 Linux
-  make
-  ./methane
+```bash
+make
+./methane
+```
 
 WebSite:
 http://methane.sourceforge.net/index.html


### PR DESCRIPTION
Previously, Markdown mistook that for prose and ate the line breaks.