### PR TITLE
Add missing unistd.h includes

### DIFF
--- a/Sources/TinyClan/Core/IOData/file_help.cpp
+++ b/Sources/TinyClan/Core/IOData/file_help.cpp
@@ -35,6 +35,7 @@
 
 #ifndef WIN32
 #include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 namespace clan

--- a/Sources/TinyClan/Core/IOData/path_help.cpp
+++ b/Sources/TinyClan/Core/IOData/path_help.cpp
@@ -43,6 +43,7 @@
 
 #ifndef WIN32
 #include <cstring>
+#include <unistd.h>
 #endif
 
 namespace clan

--- a/Sources/TinyClan/Core/Text/console_logger.cpp
+++ b/Sources/TinyClan/Core/Text/console_logger.cpp
@@ -32,6 +32,10 @@
 #include "API/Core/Text/string_help.h"
 #include "API/Core/Text/string_format.h"
 
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
 namespace clan
 {
 	ConsoleLogger::ConsoleLogger()


### PR DESCRIPTION
- `file_help.cpp`: needed for `unlink()`
- `path_help.cpp`: needed for `getcwd()`
- `console_logger.cpp`: needed for `write()`